### PR TITLE
fixed github url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ],    
     "repository": {
         "type": "git",
-        "url": "git@github.com:kof/node-argsparser.git"
+        "url": "http://github.com/kof/node-jqtpl.git"
     },
     "keywords": ["template", "template engine", "jquery", "django"],
     "directories": { "lib": "./lib" },


### PR DESCRIPTION
github url now points to the public read-only url (and for the correct project ;-)
