### PR TITLE
Fix for node-jqtpl on Couchdb

### DIFF
--- a/lib/jqtpl.js
+++ b/lib/jqtpl.js
@@ -97,7 +97,7 @@ exports.render = function( str, data ) {
         data = {};
         dataType = "object";
     } else {
-        dataType = Array.isArray(data  ) ? "array" : typeof data;
+        dataType = data instanceof Array ? "array" : typeof data;
     }
     
     if ( !fn ) {


### PR DESCRIPTION
Hi!

I replaced isArray() in jqtpl.js.
The following alternatives do work with Couchdb, i choosed the second one:
        dataType = data.constructor.toString().indexOf("Array") == 0 ? "array" : typeof data; // works
        dataType = data instanceof Array ? "array" : typeof data; // works
        dataType = data.constructor == Array ? "array" : typeof data; // works

Cheers!
webwurst
(First time using git and github..)
