### PR TITLE
moved qunit to devDependencies for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "main": "./lib/jqtpl.js",
     "engines": { "node": ">= 0.3.7" },
     "dependencies": {
-        "express": ">= 1.0.7",
+        "express": ">= 1.0.7"
+    },
+    "devDependencies": {
         "qunit": ">= 0.1.3"
     },
     "licenses": [


### PR DESCRIPTION
a normal user should not have to compile qunit to use the library
