### PR TITLE
fix Express dependency meta-data, add Express 2.0 support

### DIFF
--- a/lib/jqtpl.js
+++ b/lib/jqtpl.js
@@ -1,3 +1,5 @@
+exports.x = __filename;
+
 /*jslint evil: true*/
 /**
  * Port of jQuery's Template Engine to Nodejs.
@@ -107,7 +109,7 @@ exports.tag = {
 
 
 /**
- * Support Express render method
+ * Support Express render method (used by Express < 2.0)
  *
  * @param {string} markup html string.
  * @param {Object} options
@@ -138,6 +140,41 @@ exports.render = function(markup, options) {
     }
 
     return tpl;
+};
+
+/**
+ * Support Express compile method (used by Express >= 2.0)
+ *
+ * @param {string} markup html string.
+ * @param {Object} options
+ *     `locals` Local variables object.
+ *     `cache` Compiled functions are cached, requires `filename`.
+ *     `filename` Used by `cache` to key caches.
+ *     `scope` Function execution context.
+ *     `debug` Output generated function body.
+ *
+ * @return {string} rendered html string.
+ * @export
+ */
+exports.compile = function(markup, options) {
+    var name = options.filename || markup;
+		
+    // precompile the template and cache it using filename
+    exports.template(name, markup);
+
+    return function render(options) {
+		var tpl = exports.tmpl(name, options);
+		
+	    if (options.debug) {
+	        exports.debug(exports.template[name]);
+	    }
+	
+	    if (!options.cache) {
+	        delete exports.template[name];
+	    }
+	
+		return tpl;
+	}
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jqtpl",
     "description": "A port of jQuery's template engine",
-    "version": "0.0.91",
+    "version": "0.0.100",
     "author": "Oleg Slobodskoi <oleg008@gmail.com>",
     "contributors": [
         { "name": "John Resig", "email": "jeresig@gmail.com" },
@@ -16,7 +16,7 @@
     "main": "./lib/jqtpl.js",
     "engines": { "node": ">= 0.3.7" },
     "dependencies": {
-        "express": ">=1.0.7 <2.0"
+        "express": ">=1.0.7 || ~2.0"
     },
     "devDependencies": {
         "qunit": ">= 0.1.3"


### PR DESCRIPTION
See commit log comments for details; this adds first-pass support for Express 2.0, while retaining compatibility with older versions of Express. 
