### PR TITLE
Report template syntax/compile error locations

### DIFF
--- a/lib/jqtpl.js
+++ b/lib/jqtpl.js
@@ -283,7 +283,7 @@ function buildTmplFn(markup) {
     var source = (
         'var call,_=[],$data=$item.data;' +
         // Introduce the data as local variables using with(){}
-        'with($data){_.push("\\n' + 
+        'with($data){_.push("' + 
             source +
         '");}' +
         'return _.join("");'


### PR DESCRIPTION
This sequence of commits begins the process of adding decent error location reporting -- here, we add line/offset info to errors for invalid tags, giving the exact location of the bogus tag. Expanding it to report other compile-time errors should be easy -- I just need some test cases to figure out how they might happen.

Next, annotating the generated code with the same information for render-time reporting shouldn't be difficult; just a matter of generating tracking code for line/offset info in with the expanded tag code.

This may be getting too far away from the native impl, so if you think this is too intrusive, let me know and I'll move it to a branch in my local fork.
