### PR TITLE
Fixed bug in HTML escaping of apostrophe.

### DIFF
--- a/lib/jqtpl.js
+++ b/lib/jqtpl.js
@@ -52,7 +52,7 @@ exports.escape = function(str) {
         .replace(/&(?!\w+;)/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/'/g, '&#39')
+        .replace(/'/g, '&#39;')
         .replace(/"/g, '&quot;');
 };
 


### PR DESCRIPTION
The code was missing the trailing semi-colon in `&#39;`. This was leading to a syntax error in my app where I had a piece of JavaScript like `var foo = 'hello';` since the trailing semi-colon was then lost.

Thanks to @gasi for finding the line to fix!
