### PR TITLE
Bad interactions with Express caching

### DIFF
--- a/lib/jqtpl.express.js
+++ b/lib/jqtpl.express.js
@@ -48,7 +48,7 @@ exports.compile = function(markup, options) {
     jqtpl.template(name, markup);
     
     return function render(locals) {
-		var tpl = jqtpl.tmpl(name, locals, options);
+		var tpl = jqtpl.tmpl(name, locals, locals);
 
 	    if (options.debug) {
             // print the template generator fn


### PR DESCRIPTION
Hi,

I've had a couple of bad results when using this module with Node and Express in production mode (NODE_ENV=production).

First, the jqtpl cache uses filenames as cache-line IDs. The filenames passed by express are the same for Partials as for Layouts and other Views, which means the cache lines collide, causing sadness.

Second, as per this patch, the options passed in to compile are also cached. This is probably reasonable, but options.scope is (I believe) intended to be render-time dynamic rather than cached at compile time. So this patch works around that.

It's not a patch I recommend you apply, but it would be great to review how this module could be made to play nicely with Express in production. 

Otherwise, we're pretty happy with it :)

Thanks,

Arthur
