### PR TITLE
changing $.escape to $.encode to ensure compatibility with the browser version of jquery.tmpl 

### DIFF
--- a/lib/jqtpl.js
+++ b/lib/jqtpl.js
@@ -47,7 +47,7 @@ exports.each = function(obj, callback) {
  * @return {string} str escaped html string.
  * @export
  */
-exports.escape = function(str) {
+exports.encode = function(str) {
     return String(str)
         .replace(/&(?!\w+;)/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -96,7 +96,7 @@ exports.tag = {
     '=': {
         // Encoded expression evaluation. Abbreviated form is ${}.
         _default: { $1: '$data' },
-        open: 'if($notnull_1){_.push($.escape($1a));}'
+        open: 'if($notnull_1){_.push($.encode($1a));}'
     },
     '!': {
         // Comment tag. Skipped by parser


### PR DESCRIPTION
Currently, your library references $.escape rather than $.encode, which differs from the official implementation. This causes an error in the browser if you use your library to precompile jquery templates and ultimately parse them with the official library.

Here's the line in the official repo:
https://github.com/jquery/jquery-tmpl/blob/master/jquery.tmpl.js#L241
