### PR TITLE
Default value support for evaluation expression

### DIFF
--- a/lib/jqtpl.js
+++ b/lib/jqtpl.js
@@ -96,7 +96,7 @@ exports.tag = {
     '=': {
         // Encoded expression evaluation. Abbreviated form is ${}.
         _default: { $1: '$data' },
-        open: 'if($notnull_1){_.push($.escape($1a));}'
+        open: 'if($notnull_1){_.push($.escape($1a));}else{if($default_1!=undefined)_.push($default_1)}',
     },
     '!': {
         // Comment tag. Skipped by parser
@@ -151,6 +151,9 @@ function buildTmplFn(markup) {
 
                         if (target) {
                             target = unescape(target);
+							target = target.split('|');
+							var default_value = '' + target[1];
+							target = target[0];
                             args = args ? (',' + unescape(args) + ')') : (parens ? ')' : '');
                             // Support for target being things like a.toLowerCase();
                             // In that case don't call with template item as 'this' pointer. Just evaluate...
@@ -164,6 +167,7 @@ function buildTmplFn(markup) {
                             tag[slash ? 'close' : 'open']
                                 .split('$notnull_1').join(target ? 'typeof(' + target + ')!=="undefined" && (' + target + ')!=null' : 'true')
                                 .split('$1a').join(exprAutoFnDetect)
+                                .split('$default_1').join(default_value)
                                 .split('$1').join(expr)
                                 .split('$2').join(fnargs || def.$2 || '') +
                             '_.push("';

--- a/test/jqtpl.js
+++ b/test/jqtpl.js
@@ -126,3 +126,10 @@ test('{{tmpl}}', function() {
 test('{{!}}', function() {
     equal( tmpl("<div>{{! its a comment}}</div>", {a:1}), "<div></div>", "comments work" );    
 });
+
+test('${x|"default"}', function() {
+	equal( tmpl("<div>${a|'doggy'}</div>", {a:1}), "<div>1</div>", "use not null value when default is defined" );    
+	equal( tmpl("<div>${a|'doggy'}</div>", {a:null}), "<div>doggy</div>", "use default value when value is null" );
+	equal( tmpl("<div>${a|somevar}</div>", {a:null, somevar:10}), "<div>10</div>", "use default value when value is null" );
+});
+


### PR DESCRIPTION
Our templates are full code like this

```
{{if some_var}}
<div class="foobar">${some_var}</div>
{{else}}
<div class="foobar">Something</div>
{{/if}}
```

This is not very readable, so I implemented a default value support for variable expression

```
<div class="foobar">${some_var|"Something"}</div>
```

and it supports variables as default value.

```
<div class="foobar">${some_var|other_var}</div>
```

Commit has unit test code, but I spent nearly hour trying to get qunit up and running with node 0.4 and gave up. The change was tested by ad hoc scripts and of course using it with our existing templates but no idea if all unit tests pass.
