### PR TITLE
Fix problem with locals while using jqtpl from express

### DIFF
--- a/lib/jqtpl.express.js
+++ b/lib/jqtpl.express.js
@@ -52,8 +52,8 @@ exports.compile = function(markup, options) {
         exports.debug(jqtpl.template[name]);
     }
         
-    return function render(locals) {
-		return jqtpl.tmpl(name, locals, options);
+    return function render(opts) {
+        return jqtpl.tmpl(name, opts.locals, options);
 	};
 };
 


### PR DESCRIPTION
When expressjs calls the render method in jqtpl it passes the whole options object, instead of the locals object. So the method in jqtpl must take the locals from that options object.

Regards.
